### PR TITLE
test: run e2e tests across routers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,12 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   e2e:
-    name: E2E Test
+    name: E2E Test (${{ matrix.router }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        router: [plug, phoenix]
 
     steps:
       - uses: actions/checkout@v6.0.3
@@ -101,7 +105,7 @@ jobs:
         run: nix develop -c make build
 
       - name: Run e2e tests
-        run: nix develop -c make test-e2e
+        run: nix develop -c make test-e2e E2E_ROUTER=${{ matrix.router }}
 
   formatter:
     name: Formatter

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,11 @@ unit-test:
 test:
 	MIX_ENV=test mix test
 
+E2E_ROUTER ?= plug
+
 .PHONY: test-e2e
 test-e2e:
-	MIX_ENV=test mix test --only integration --max-cases 1
+	MIX_ENV=test INNGEST_TEST_ROUTER=$(E2E_ROUTER) mix test --only integration --max-cases 1
 
 .PHONY: test-cover
 test-cover:

--- a/docs/development/serve-api.md
+++ b/docs/development/serve-api.md
@@ -6,9 +6,11 @@ in your project.
 
 ## Setting up
 
-The Elixir SDK provides an `inngest` macro, that will setup the required API endpints
-to your router. The recommended path is `/api/inngest` since it makes it obvious where
+The Elixir SDK provides an `inngest` macro, that will setup the required API endpoints
+in your router. The recommended path is `/api/inngest` since it makes it obvious where
 the endpoints are, but you can change it to whatever you see fit.
+
+Define a first-class client for the functions your app serves:
 
 ```elixir
 defmodule MyApp.Inngest do
@@ -19,11 +21,53 @@ defmodule MyApp.Inngest do
       MyApp.CronFn
     ]
 end
+```
 
+### Plug.Router
+
+For a `Plug.Router` app, use the Plug router integration:
+
+```elixir
 defmodule MyApp.Router do
   use Inngest.Router, :plug
 
   inngest("/api/inngest", client: MyApp.Inngest)
+end
+```
+
+### Phoenix.Router
+
+For a Phoenix app, add the router integration to your Phoenix router and mount
+the same client:
+
+```elixir
+defmodule MyAppWeb.Router do
+  use MyAppWeb, :router
+  use Inngest.Router, :phoenix
+
+  scope "/" do
+    pipe_through(:api)
+
+    inngest("/api/inngest", client: MyApp.Inngest)
+  end
+end
+```
+
+Signed Inngest requests are verified against the raw request body. Phoenix apps
+usually parse request bodies in the endpoint before the router runs, so configure
+the endpoint parser with `Inngest.CacheBodyReader`:
+
+```elixir
+defmodule MyAppWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :my_app
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    body_reader: {Inngest.CacheBodyReader, :read_body, []},
+    json_decoder: Phoenix.json_library()
+
+  plug MyAppWeb.Router
 end
 ```
 

--- a/lib/inngest/router/phoenix.ex
+++ b/lib/inngest/router/phoenix.ex
@@ -3,7 +3,29 @@ defmodule Inngest.Router.Phoenix do
   Router module expected to be used with a `Phoenix` router.
 
   ## Examples
-      use Inngest.Router, :phoenix
+      defmodule MyAppWeb.Router do
+        use MyAppWeb, :router
+        use Inngest.Router, :phoenix
+
+        scope "/" do
+          pipe_through(:api)
+
+          inngest("/api/inngest", client: MyApp.Inngest)
+        end
+      end
+
+  Inngest verifies inbound request signatures against the raw request body. In
+  Phoenix applications, configure `Plug.Parsers` with
+  `Inngest.CacheBodyReader` in your endpoint so the router can verify signed
+  requests:
+
+      plug Plug.Parsers,
+        parsers: [:urlencoded, :multipart, :json],
+        pass: ["*/*"],
+        body_reader: {Inngest.CacheBodyReader, :read_body, []},
+        json_decoder: Phoenix.json_library()
+
+      plug MyAppWeb.Router
   """
   @framework "phoenix"
 

--- a/test/support/application.ex
+++ b/test/support/application.ex
@@ -8,7 +8,7 @@ defmodule Inngest.Test.Application do
   def start(_type, _args) do
     children = [
       {Finch, name: Inngest.Finch},
-      Inngest.Test.PlugRouter
+      router()
     ]
 
     children =
@@ -18,6 +18,14 @@ defmodule Inngest.Test.Application do
 
     opts = [strategy: :one_for_one, name: Inngest.Test.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp router do
+    case System.get_env("INNGEST_TEST_ROUTER", "plug") do
+      "plug" -> Inngest.Test.PlugRouter
+      "phoenix" -> Inngest.Test.PhoenixRouter
+      other -> raise "unsupported INNGEST_TEST_ROUTER=#{inspect(other)}"
+    end
   end
 
   defp start_dev_server? do

--- a/test/support/router/phoenix.ex
+++ b/test/support/router/phoenix.ex
@@ -1,0 +1,45 @@
+defmodule Inngest.Test.PhoenixRouter do
+  @moduledoc false
+
+  use Phoenix.Router
+  use Inngest.Router, :phoenix
+  require Logger
+
+  pipeline :inngest_api do
+    plug(Plug.Logger)
+
+    plug(Plug.Parsers,
+      parsers: [:urlencoded, :json],
+      pass: ["text/*"],
+      body_reader: {Inngest.CacheBodyReader, :read_body, []},
+      json_decoder: Jason
+    )
+  end
+
+  scope "/" do
+    pipe_through(:inngest_api)
+
+    inngest("/api/inngest", client: Inngest.Test.Client)
+  end
+
+  def start_link() do
+    webserver =
+      {Plug.Cowboy, plug: Inngest.Test.PhoenixRouter, scheme: :http, options: [port: 4000]}
+
+    case Supervisor.start_link([webserver], strategy: :one_for_one) do
+      {:ok, _pid} = result ->
+        Logger.info("Phoenix server listening on 127.0.0.1:4000")
+        result
+
+      error ->
+        error
+    end
+  end
+
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []}
+    }
+  end
+end

--- a/test/support/router/plug.ex
+++ b/test/support/router/plug.ex
@@ -63,18 +63,17 @@ defmodule Inngest.Test.PlugRouter do
   end
 
   def start_link() do
-    task =
-      Task.async(fn ->
-        webserver =
-          {Plug.Cowboy, plug: Inngest.Test.PlugRouter, scheme: :http, options: [port: 4000]}
+    webserver =
+      {Plug.Cowboy, plug: Inngest.Test.PlugRouter, scheme: :http, options: [port: 4000]}
 
-        {:ok, _} = Supervisor.start_link([webserver], strategy: :one_for_one)
+    case Supervisor.start_link([webserver], strategy: :one_for_one) do
+      {:ok, _pid} = result ->
         Logger.info("Server listening on 127.0.0.1:4000")
+        result
 
-        Process.sleep(:infinity)
-      end)
-
-    {:ok, task.pid}
+      error ->
+        error
+    end
   end
 
   def child_spec(_) do


### PR DESCRIPTION
## Summary
- add a Phoenix router fixture for the e2e test harness
- make local e2e runs selectable with `make test-e2e E2E_ROUTER=plug|phoenix`
- run the CI e2e job as a Plug/Phoenix router matrix
- start test Cowboy servers synchronously so dev-server discovery waits for the route to bind
- document Phoenix router and endpoint parser setup in HexDocs-facing docs

## Validation
- `make test-e2e E2E_ROUTER=phoenix`
- `make test-e2e E2E_ROUTER=plug`
- `make fmt`
- `make build`
- `make lint`
- `MIX_ENV=test UNIT=true INNGEST_TEST_ROUTER=phoenix mix test test/inngest/router/introspection_test.exs`