### PR TITLE
fix: harden cached body handling

### DIFF
--- a/docs/development/serve-api.md
+++ b/docs/development/serve-api.md
@@ -62,14 +62,19 @@ defmodule MyAppWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :my_app
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
+    parsers: [:urlencoded, :json],
     pass: ["*/*"],
-    body_reader: {Inngest.CacheBodyReader, :read_body, []},
+    body_reader: {Inngest.CacheBodyReader, :read_body, [[paths: ["/api/inngest"]]]},
     json_decoder: Phoenix.json_library()
 
   plug MyAppWeb.Router
 end
 ```
+
+The `paths:` option avoids copying unrelated request bodies when `Plug.Parsers`
+runs globally in your endpoint. Plug's multipart parser does not use
+`:body_reader`; Inngest signed requests are JSON, so the `:json` parser is the
+important one for signature verification.
 
 Accepted arguments for the `inngest` macros are
 

--- a/docs/development/serve-api.md
+++ b/docs/development/serve-api.md
@@ -35,6 +35,12 @@ defmodule MyApp.Router do
 end
 ```
 
+The generated Plug routes parse JSON and urlencoded Inngest request bodies with
+`Inngest.CacheBodyReader` by default. You do not need to add a `Plug.Parsers`
+plug only for Inngest. If your router already runs `Plug.Parsers` before
+dispatching to the Inngest route, configure that parser with
+`Inngest.CacheBodyReader` so signed requests can still be verified.
+
 ### Phoenix.Router
 
 For a Phoenix app, add the router integration to your Phoenix router and mount

--- a/lib/inngest/cache_body_reader.ex
+++ b/lib/inngest/cache_body_reader.ex
@@ -1,15 +1,78 @@
 defmodule Inngest.CacheBodyReader do
   @moduledoc """
-  A custom Plug parser for caching raw request body
+  A custom Plug parser for caching raw request bodies.
+
+  Inngest verifies inbound request signatures against the raw request body.
+  `Plug.Parsers` consumes that body while parsing, so this reader stores the
+  bytes in connection private data before the parser discards them.
+
+  Use `paths:` to limit caching to the Inngest endpoint when the parser runs
+  globally in a Phoenix endpoint:
+
+      plug Plug.Parsers,
+        parsers: [:urlencoded, :json],
+        pass: ["*/*"],
+        body_reader: {Inngest.CacheBodyReader, :read_body, [[paths: ["/api/inngest"]]]},
+        json_decoder: Phoenix.json_library()
+
+  Plug's multipart parser does not use the `:body_reader` option.
   """
-  @spec read_body(Plug.Conn.t(), keyword()) :: {:ok, binary(), Plug.Conn.t()}
+
+  @raw_body_key :inngest_raw_body
+
+  @type read_result ::
+          {:ok, binary(), Plug.Conn.t()}
+          | {:more, binary(), Plug.Conn.t()}
+          | {:error, term()}
+
+  @spec read_body(Plug.Conn.t(), keyword()) :: read_result()
   def read_body(conn, opts) do
-    {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
-    conn = update_in(conn.private[:raw_body], &[body | &1 || []])
-    {:ok, body, conn}
+    read_body(conn, opts, [])
   end
 
+  @spec read_body(Plug.Conn.t(), keyword(), keyword()) :: read_result()
+  def read_body(conn, opts, reader_opts) do
+    case Plug.Conn.read_body(conn, opts) do
+      {:ok, body, conn} ->
+        {:ok, body, maybe_cache_body(conn, body, reader_opts)}
+
+      {:more, body, conn} ->
+        {:more, body, maybe_cache_body(conn, body, reader_opts)}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @spec read_cached_body(Plug.Conn.t()) :: binary()
   def read_cached_body(conn) do
-    conn.private[:raw_body]
+    conn.private
+    |> Map.get(@raw_body_key, [])
+    |> Enum.reverse()
+    |> IO.iodata_to_binary()
+  end
+
+  defp maybe_cache_body(conn, body, opts) do
+    if cache_body?(conn, opts) do
+      Plug.Conn.put_private(conn, @raw_body_key, [body | Map.get(conn.private, @raw_body_key, [])])
+    else
+      conn
+    end
+  end
+
+  defp cache_body?(conn, opts) do
+    case Keyword.get(opts, :paths) do
+      nil -> true
+      paths -> normalize_path(conn.request_path) in Enum.map(List.wrap(paths), &normalize_path/1)
+    end
+  end
+
+  defp normalize_path(path) when is_binary(path) do
+    path
+    |> String.trim_trailing("/")
+    |> case do
+      "" -> "/"
+      normalized -> normalized
+    end
   end
 end

--- a/lib/inngest/router/introspection.ex
+++ b/lib/inngest/router/introspection.ex
@@ -112,6 +112,5 @@ defmodule Inngest.Router.Introspection do
 
   defp mode(client), do: client.mode |> Atom.to_string()
 
-  defp raw_body(%{private: %{raw_body: body}}) when is_list(body), do: Enum.join(body)
-  defp raw_body(_conn), do: ""
+  defp raw_body(conn), do: Inngest.CacheBodyReader.read_cached_body(conn)
 end

--- a/lib/inngest/router/invoke.ex
+++ b/lib/inngest/router/invoke.ex
@@ -229,8 +229,7 @@ defmodule Inngest.Router.Invoke do
     end
   end
 
-  defp raw_body(%{private: %{raw_body: body}}) when is_list(body), do: Enum.join(body)
-  defp raw_body(_conn), do: ""
+  defp raw_body(conn), do: Inngest.CacheBodyReader.read_cached_body(conn)
 
   defp maybe_retrieve_full_payload(
          %{"ctx" => %{"use_api" => true, "run_id" => run_id}} = params,

--- a/lib/inngest/router/phoenix.ex
+++ b/lib/inngest/router/phoenix.ex
@@ -20,12 +20,16 @@ defmodule Inngest.Router.Phoenix do
   requests:
 
       plug Plug.Parsers,
-        parsers: [:urlencoded, :multipart, :json],
+        parsers: [:urlencoded, :json],
         pass: ["*/*"],
-        body_reader: {Inngest.CacheBodyReader, :read_body, []},
+        body_reader: {Inngest.CacheBodyReader, :read_body, [[paths: ["/api/inngest"]]]},
         json_decoder: Phoenix.json_library()
 
       plug MyAppWeb.Router
+
+  Plug's multipart parser does not use the `:body_reader` option. Inngest
+  signed requests are JSON, so the `:json` parser is the important one for
+  signature verification.
   """
   @framework "phoenix"
 

--- a/lib/inngest/router/plug.ex
+++ b/lib/inngest/router/plug.ex
@@ -4,8 +4,19 @@ defmodule Inngest.Router.Plug do
 
   ## Examples
       use Inngest.Router, :plug
+
+  Generated Inngest routes parse JSON and urlencoded request bodies with
+  `Inngest.CacheBodyReader` before invoking functions or syncing
+  registrations. If your router runs another `Plug.Parsers` plug before
+  dispatching to Inngest, configure that parser with `Inngest.CacheBodyReader`
+  so signed requests can still be verified against the raw request body.
   """
   @framework "plug"
+  @parser_opts [
+    parsers: [:urlencoded, :json],
+    pass: ["*/*"],
+    json_decoder: Jason
+  ]
 
   defmacro __using__(_opts) do
     quote do
@@ -39,6 +50,7 @@ defmodule Inngest.Router.Plug do
         opts = Inngest.Router.Invoke.init(unquote(opts))
 
         var!(conn)
+        |> Inngest.Router.Plug.__parse_body__(unquote(path))
         |> Inngest.Router.Invoke.call(opts)
       end
 
@@ -47,9 +59,20 @@ defmodule Inngest.Router.Plug do
         opts = Inngest.Router.Register.init(unquote(opts))
 
         var!(conn)
+        |> Inngest.Router.Plug.__parse_body__(unquote(path))
         |> Inngest.Router.Register.call(opts)
       end
     end
+  end
+
+  @doc false
+  def __parse_body__(conn, path) do
+    opts =
+      @parser_opts
+      |> Keyword.put(:body_reader, {Inngest.CacheBodyReader, :read_body, [[paths: [path]]]})
+      |> Plug.Parsers.init()
+
+    Plug.Parsers.call(conn, opts)
   end
 
   defp expand_alias({:__aliases__, _, _} = alias, env),

--- a/lib/inngest/router/register.ex
+++ b/lib/inngest/router/register.ex
@@ -112,6 +112,5 @@ defmodule Inngest.Router.Register do
     end
   end
 
-  defp raw_body(%{private: %{raw_body: body}}) when is_list(body), do: Enum.join(body)
-  defp raw_body(_conn), do: ""
+  defp raw_body(conn), do: Inngest.CacheBodyReader.read_cached_body(conn)
 end

--- a/test/inngest/cache_body_reader_test.exs
+++ b/test/inngest/cache_body_reader_test.exs
@@ -18,19 +18,54 @@ defmodule Inngest.CacheBodyReaderTest do
   end
 
   describe "read_body/2" do
-    test "should cache body in assigns", %{conn: conn} do
+    test "caches body in private data", %{conn: conn} do
       assert {:ok, _body,
               %{
-                private: %{raw_body: [raw]}
+                private: %{inngest_raw_body: [raw]}
               }} = CacheBodyReader.read_body(conn, [])
 
       assert {:ok, body} = Jason.decode(raw)
       assert body == @body
     end
+
+    test "caches multi-read bodies in request order" do
+      conn =
+        conn(:post, "/api/inngest", "abcdef")
+        |> put_req_header("content-type", "application/json")
+
+      assert {:more, "abc", conn} = CacheBodyReader.read_body(conn, read_length: 3, length: 3)
+      assert {:ok, "def", conn} = CacheBodyReader.read_body(conn, read_length: 3, length: 3)
+
+      assert "abcdef" == CacheBodyReader.read_cached_body(conn)
+    end
+  end
+
+  describe "read_body/3" do
+    test "caches matching request paths", %{conn: conn, raw: raw} do
+      assert {:ok, _body, conn} = CacheBodyReader.read_body(conn, [], paths: ["/api/inngest"])
+      assert raw == CacheBodyReader.read_cached_body(conn)
+    end
+
+    test "caches matching request paths with trailing slashes", %{raw: raw} do
+      conn =
+        conn(:post, "/api/inngest/", raw)
+        |> put_req_header("content-type", "application/json")
+
+      assert {:ok, _body, conn} = CacheBodyReader.read_body(conn, [], paths: ["/api/inngest"])
+      assert raw == CacheBodyReader.read_cached_body(conn)
+    end
+
+    test "skips caching unrelated request paths", %{raw: raw} do
+      conn =
+        conn(:post, "/api/users", raw)
+        |> put_req_header("content-type", "application/json")
+
+      assert {:ok, _body, conn} = CacheBodyReader.read_body(conn, [], paths: ["/api/inngest"])
+      assert "" == CacheBodyReader.read_cached_body(conn)
+    end
   end
 
   describe "read_cached_body/1" do
-    @tag :skip
     test "should be able to read cached body", %{conn: conn, raw: raw} do
       assert {:ok, _body, conn} = CacheBodyReader.read_body(conn, [])
       assert raw == CacheBodyReader.read_cached_body(conn)

--- a/test/inngest/middleware_test.exs
+++ b/test/inngest/middleware_test.exs
@@ -502,7 +502,7 @@ defmodule Inngest.MiddlewareTest do
   defp invoke_conn(body, params) do
     :post
     |> conn("/api/inngest", body)
-    |> Plug.Conn.put_private(:raw_body, [body])
+    |> Plug.Conn.put_private(:inngest_raw_body, [body])
     |> Map.put(:params, params)
   end
 

--- a/test/inngest/router/introspection_test.exs
+++ b/test/inngest/router/introspection_test.exs
@@ -266,7 +266,7 @@ defmodule Inngest.Router.IntrospectionTest do
   defp introspection_conn do
     :get
     |> conn("/api/inngest", "")
-    |> Plug.Conn.put_private(:raw_body, [""])
+    |> Plug.Conn.put_private(:inngest_raw_body, [""])
   end
 
   defp unauthenticated_keys do

--- a/test/inngest/router/invoke_test.exs
+++ b/test/inngest/router/invoke_test.exs
@@ -394,7 +394,7 @@ defmodule Inngest.Router.InvokeTest do
   defp invoke_conn(body, params) do
     :post
     |> conn("/api/inngest", body)
-    |> Plug.Conn.put_private(:raw_body, [body])
+    |> Plug.Conn.put_private(:inngest_raw_body, [body])
     |> Map.put(:params, params)
   end
 

--- a/test/inngest/router/plug_test.exs
+++ b/test/inngest/router/plug_test.exs
@@ -1,0 +1,75 @@
+defmodule Inngest.Router.PlugTestFn do
+  @moduledoc false
+
+  use Inngest.Function
+
+  @func %FnOpts{id: "plug-test", name: "Plug Test"}
+  @trigger %Trigger{event: "test/router.plug"}
+
+  @impl true
+  def exec(_ctx, input) do
+    send(Application.fetch_env!(:inngest, :plug_router_test_pid), {:input, input})
+    {:ok, %{"ok" => true}}
+  end
+end
+
+defmodule Inngest.Router.PlugTestClient do
+  @moduledoc false
+
+  use Inngest.Client,
+    id: "plug-router-app",
+    funcs: [Inngest.Router.PlugTestFn],
+    mode: :dev
+end
+
+defmodule Inngest.Router.PlugTestRouter do
+  @moduledoc false
+
+  use Plug.Router
+  use Inngest.Router, :plug
+
+  plug(:match)
+  plug(:dispatch)
+
+  inngest("/api/inngest", client: Inngest.Router.PlugTestClient)
+end
+
+defmodule Inngest.Router.PlugTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Conn
+  import Plug.Test
+
+  setup do
+    config = Application.fetch_env(:inngest, :plug_router_test_pid)
+    Application.put_env(:inngest, :plug_router_test_pid, self())
+
+    on_exit(fn ->
+      case config do
+        {:ok, value} -> Application.put_env(:inngest, :plug_router_test_pid, value)
+        :error -> Application.delete_env(:inngest, :plug_router_test_pid)
+      end
+    end)
+  end
+
+  test "parses invoke bodies with the cached body reader by default" do
+    body =
+      Jason.encode!(%{
+        "event" => %{"name" => "test/router.plug", "data" => %{"hello" => "world"}},
+        "events" => [%{"name" => "test/router.plug", "data" => %{"hello" => "world"}}],
+        "ctx" => %{"run_id" => "run-1", "attempt" => 0, "use_api" => false},
+        "fnId" => Inngest.Router.PlugTestFn.slug(Inngest.Router.PlugTestClient.client().id),
+        "steps" => %{}
+      })
+
+    conn =
+      :post
+      |> conn("/api/inngest", body)
+      |> put_req_header("content-type", "application/json")
+      |> Inngest.Router.PlugTestRouter.call([])
+
+    assert conn.status == 200
+    assert Inngest.CacheBodyReader.read_cached_body(conn) == body
+    assert_receive {:input, %{event: %{data: %{"hello" => "world"}}}}
+  end
+end

--- a/test/inngest/router/register_test.exs
+++ b/test/inngest/router/register_test.exs
@@ -274,7 +274,7 @@ defmodule Inngest.Router.RegisterTest do
   defp register_conn(body, params \\ %{}) do
     :put
     |> conn("/api/inngest", body)
-    |> Plug.Conn.put_private(:raw_body, [body])
+    |> Plug.Conn.put_private(:inngest_raw_body, [body])
     |> Map.put(:params, params)
   end
 

--- a/test/support/dev_server.ex
+++ b/test/support/dev_server.ex
@@ -28,10 +28,13 @@ defmodule Inngest.Test.DevServer do
         :stderr_to_stdout
       ])
 
+    os_pid = os_pid(port)
+    System.at_exit(fn _status -> terminate_os_process(os_pid) end)
+
     wait_until_ready()
     Process.sleep(@discovery_interval)
 
-    {:ok, %{port: port, os_pid: os_pid(port), logs: []}}
+    {:ok, %{port: port, os_pid: os_pid, logs: []}}
   end
 
   @impl true

--- a/test/support/dev_server.ex
+++ b/test/support/dev_server.ex
@@ -31,7 +31,7 @@ defmodule Inngest.Test.DevServer do
     wait_until_ready()
     Process.sleep(@discovery_interval)
 
-    {:ok, %{port: port, logs: []}}
+    {:ok, %{port: port, os_pid: os_pid(port), logs: []}}
   end
 
   @impl true
@@ -48,8 +48,9 @@ defmodule Inngest.Test.DevServer do
   end
 
   @impl true
-  def terminate(_reason, %{port: port}) when is_port(port) do
+  def terminate(_reason, %{port: port, os_pid: os_pid}) when is_port(port) do
     if Port.info(port), do: Port.close(port)
+    terminate_os_process(os_pid)
   end
 
   def terminate(_reason, _state), do: :ok
@@ -86,6 +87,39 @@ defmodule Inngest.Test.DevServer do
     System.find_executable("inngest-cli") ||
       System.find_executable("inngest") ||
       raise "inngest-cli executable is required for integration tests"
+  end
+
+  defp os_pid(port) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, pid} -> pid
+      nil -> nil
+    end
+  end
+
+  defp terminate_os_process(pid) when is_integer(pid) do
+    pid = Integer.to_string(pid)
+
+    System.cmd("kill", ["-TERM", pid], stderr_to_stdout: true)
+    Process.sleep(100)
+
+    if process_alive?(pid) do
+      System.cmd("kill", ["-KILL", pid], stderr_to_stdout: true)
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp terminate_os_process(_pid), do: :ok
+
+  defp process_alive?(pid) do
+    case System.cmd("kill", ["-0", pid], stderr_to_stdout: true) do
+      {_, 0} -> true
+      _ -> false
+    end
+  rescue
+    _ -> false
   end
 
   defp wait_until_ready(retries \\ @startup_retries)

--- a/test/support/router/phoenix.ex
+++ b/test/support/router/phoenix.ex
@@ -11,7 +11,7 @@ defmodule Inngest.Test.PhoenixRouter do
     plug(Plug.Parsers,
       parsers: [:urlencoded, :json],
       pass: ["text/*"],
-      body_reader: {Inngest.CacheBodyReader, :read_body, []},
+      body_reader: {Inngest.CacheBodyReader, :read_body, [[paths: ["/api/inngest"]]]},
       json_decoder: Jason
     )
   end

--- a/test/support/router/plug.ex
+++ b/test/support/router/plug.ex
@@ -41,7 +41,7 @@ defmodule Inngest.Test.PlugRouter do
   plug(Plug.Parsers,
     parsers: [:urlencoded, :json],
     pass: ["text/*"],
-    body_reader: {Inngest.CacheBodyReader, :read_body, []},
+    body_reader: {Inngest.CacheBodyReader, :read_body, [[paths: ["/api/inngest"]]]},
     json_decoder: Jason
   )
 

--- a/test/support/router/plug.ex
+++ b/test/support/router/plug.ex
@@ -38,13 +38,6 @@ defmodule Inngest.Test.PlugRouter do
 
   plug(Plug.Logger)
 
-  plug(Plug.Parsers,
-    parsers: [:urlencoded, :json],
-    pass: ["text/*"],
-    body_reader: {Inngest.CacheBodyReader, :read_body, [[paths: ["/api/inngest"]]]},
-    json_decoder: Jason
-  )
-
   plug(:match)
   plug(:dispatch)
 


### PR DESCRIPTION
## Summary
- harden `Inngest.CacheBodyReader` to preserve multi-read body order, pass through read errors, and use a namespaced private key
- parse JSON and urlencoded request bodies with `Inngest.CacheBodyReader` by default inside generated Plug `inngest` routes
- add optional `paths:` scoped body caching so Phoenix endpoint parsers do not copy unrelated request bodies
- update Plug/Phoenix docs and e2e router fixtures to document the default Plug behavior, scoped Phoenix caching, and the multipart parser caveat
- clean up e2e `inngest-cli` dev-server processes reliably after test runs

## Validation
- `mix test test/inngest/cache_body_reader_test.exs test/inngest/router/plug_test.exs test/inngest/router/invoke_test.exs test/inngest/router/register_test.exs test/inngest/router/introspection_test.exs`
- `make fmt`
- `make lint`
- `make build`
- `make test-e2e E2E_ROUTER=plug`
- `make test-e2e E2E_ROUTER=phoenix`
- `mix hex.build --output /private/tmp/inngest-ex-hex-build.tar`